### PR TITLE
92 – About page

### DIFF
--- a/client/src/app/(pages)/(main)/about/_components/AboutCard/AboutCard.module.scss
+++ b/client/src/app/(pages)/(main)/about/_components/AboutCard/AboutCard.module.scss
@@ -1,0 +1,16 @@
+.aboutCard {
+  height: 296px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 5px;
+  background-color: var(--darker-gray);
+  border-radius: 5px;
+  color: var(--white);
+
+  h3 {
+    font-size: 1rem;
+    font-weight: 600;
+  }
+}

--- a/client/src/app/(pages)/(main)/about/_components/AboutCard/AboutCard.tsx
+++ b/client/src/app/(pages)/(main)/about/_components/AboutCard/AboutCard.tsx
@@ -1,0 +1,16 @@
+import styles from './AboutCard.module.scss';
+
+export default function AboutCard({
+  header,
+  content,
+}: {
+  header: string;
+  content: string;
+}) {
+  return (
+    <div className={styles.aboutCard}>
+      <h3>{header}</h3>
+      <p>{content}</p>
+    </div>
+  );
+}

--- a/client/src/app/(pages)/(main)/about/page.module.scss
+++ b/client/src/app/(pages)/(main)/about/page.module.scss
@@ -1,0 +1,6 @@
+.page {
+  padding: 260px 100px;
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+}

--- a/client/src/app/(pages)/(main)/about/page.tsx
+++ b/client/src/app/(pages)/(main)/about/page.tsx
@@ -1,0 +1,29 @@
+import AboutCard from './_components/AboutCard/AboutCard';
+import styles from './page.module.scss';
+
+const ABOUT_CONTENT = [
+  {
+    header: 'About #include',
+    content:
+      '#include is a student-run organization at UC Davis that builds websites and mobile apps for local organizations in the Sacramento and Davis community. Our mission is to design and develop for social good while helping clients grow technologically. Through our projects, students gain real-world experience that strengthens their design, technical, teamwork, and communication skills—resulting in impressive products for our clients and standout portfolio pieces for our members.',
+  },
+  {
+    header: 'Our Mission',
+    content:
+      'Our mission is to create a simple, central marketplace where UC Davis clubs can easily access and share the resources they need. #include designed this space to help organizations find equipment, borrow or sell items, make quick funding, and test components before committing to a purchase.',
+  },
+];
+
+export default function About() {
+  return (
+    <div className={styles.page}>
+      {ABOUT_CONTENT.map((card) => (
+        <AboutCard
+          key={card.header}
+          header={card.header}
+          content={card.content}
+        />
+      ))}
+    </div>
+  );
+}

--- a/client/src/app/_components/Navbar/Navbar.module.scss
+++ b/client/src/app/_components/Navbar/Navbar.module.scss
@@ -97,6 +97,7 @@
   font-size: 1.125rem;
   border: none;
   border-bottom: 1px solid var(--light-gray);
+  text-decoration: none;
 }
 
 .dropdownItem:last-child {

--- a/client/src/app/_components/Navbar/Navbar.tsx
+++ b/client/src/app/_components/Navbar/Navbar.tsx
@@ -75,13 +75,14 @@ export default function Navbar() {
         </button>
         {dropdownOpen && (
           <div className={styles.dropdown} id="account-dropdown">
-            <button
+            <Link
               className={styles.dropdownItem}
               id="dropdown-about"
+              href="/about"
               onClick={() => setDropdownOpen(false)}
             >
               About
-            </button>
+            </Link>
             {isAuthenticated ? (
               <button
                 onClick={logout}


### PR DESCRIPTION
# 92 – About page

Closes #92 

## Description

Adds the about page as shown on Figma. Links "About" from navbar dropdown to new about page.

## Screenshot

<img width="1470" height="1253" alt="image" src="https://github.com/user-attachments/assets/91bc6950-9bea-4b0d-aa86-1bbb1d647b5f" />
